### PR TITLE
Fix NullReferenceException when movie has no poster

### DIFF
--- a/autotag.Core/MovieProcessor.cs
+++ b/autotag.Core/MovieProcessor.cs
@@ -100,7 +100,7 @@ namespace autotag.Core {
             result.Title = selectedResult.Title;
             result.Overview = selectedResult.Overview;
             result.CoverURL = string.IsNullOrEmpty(selectedResult.PosterPath) ? null : $"https://image.tmdb.org/t/p/original{selectedResult.PosterPath}";
-            result.CoverFilename = selectedResult.PosterPath.Replace("/", "");
+            result.CoverFilename = selectedResult.PosterPath?.Replace("/", "");
             result.Date = selectedResult.ReleaseDate.Value;
 
             if (_genres == null) {


### PR DESCRIPTION
System.NullReferenceException when no poster is present in TMDB
Tested with "The Nearly Complete and Utter History of Everything (2000)"