### PR TITLE
Fixed: Config file is not overridden anymore

### DIFF
--- a/AutoTag.CLI/AutoTag.CLI.csproj
+++ b/AutoTag.CLI/AutoTag.CLI.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>autotag</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <AssemblyVersion>3.5.0.0</AssemblyVersion>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AutoTag.CLI/Options/MiscOptions.cs
+++ b/AutoTag.CLI/Options/MiscOptions.cs
@@ -8,8 +8,8 @@ public class MiscOptions : OptionsBase<MiscOptions>, IOptionsBase<MiscOptions>
     [CommandLineOption<string>("--pattern", "-p", "Custom regex to parse TV episode information")]
     public string? ParsePattern { get; set; }
 
-    [CommandLineOption<bool>("--verbose", "-v", "Enable verbose output mode")]
-    public bool Verbose { get; set; }
+    [CommandLineOption<bool?>("--verbose", "-v", "Enable verbose output mode")]
+    public bool? Verbose { get; set; }
 
     [CommandLineOption<bool>("--set-default", "Set the current arguments as the default")]
     public bool SetDefault { get; set; }
@@ -38,9 +38,8 @@ public class MiscOptions : OptionsBase<MiscOptions>, IOptionsBase<MiscOptions>
 
     public void UpdateConfig(AutoTagConfig config)
     {
-        config.ParsePattern = ParsePattern;
-
-        config.Verbose = Verbose;
+        config.ParsePattern = string.IsNullOrWhiteSpace(ParsePattern) ? config.ParsePattern : ParsePattern;
+        config.Verbose = Verbose ?? config.Verbose;
     }
 
     private static string GetDefaultConfigPath() => Path.Combine(

--- a/AutoTag.CLI/Options/MiscOptions.cs
+++ b/AutoTag.CLI/Options/MiscOptions.cs
@@ -38,8 +38,15 @@ public class MiscOptions : OptionsBase<MiscOptions>, IOptionsBase<MiscOptions>
 
     public void UpdateConfig(AutoTagConfig config)
     {
-        config.ParsePattern = string.IsNullOrWhiteSpace(ParsePattern) ? config.ParsePattern : ParsePattern;
-        config.Verbose = Verbose ?? config.Verbose;
+        if (!string.IsNullOrWhiteSpace(ParsePattern))
+        {
+            config.ParsePattern = ParsePattern;
+        }
+
+        if (Verbose.HasValue)
+        {
+            config.Verbose = Verbose.Value;
+        }
     }
 
     private static string GetDefaultConfigPath() => Path.Combine(

--- a/AutoTag.CLI/Options/RenameOptions.cs
+++ b/AutoTag.CLI/Options/RenameOptions.cs
@@ -2,19 +2,19 @@ namespace AutoTag.CLI.Options;
 
 public class RenameOptions : OptionsBase<RenameOptions>, IOptionsBase<RenameOptions>
 {
-    [CommandLineOption<bool>("--no-rename", "Disable file and subtitle renaming")]
-    public bool NoRename { get; set; }
+    [CommandLineOption<bool?>("--no-rename", "Disable file and subtitle renaming")]
+    public bool? NoRename { get; set; }
 
     [CommandLineOption<string>("--tv-pattern", "Rename pattern for TV episodes")]
     public string? TVPattern { get; set; }
     [CommandLineOption<string>("--movie-pattern", "Rename pattern for movies")]
     public string? MoviePattern { get; set; }
 
-    [CommandLineOption<bool>("--windows-safe", "Remove invalid Windows file name characters when renaming")]
-    public bool WindowsSafe { get; set; }
+    [CommandLineOption<bool?>("--windows-safe", "Remove invalid Windows file name characters when renaming")]
+    public bool? WindowsSafe { get; set; }
 
-    [CommandLineOption<bool>("--rename-subs", "Rename subtitle files")]
-    public bool RenameSubs { get; set; }
+    [CommandLineOption<bool?>("--rename-subs", "Rename subtitle files")]
+    public bool? RenameSubs { get; set; }
 
     public static IEnumerable<Option> GetOptions()
     {
@@ -37,7 +37,7 @@ public class RenameOptions : OptionsBase<RenameOptions>, IOptionsBase<RenameOpti
 
     public void UpdateConfig(AutoTagConfig config)
     {
-        config.RenameFiles = !NoRename;
+        config.RenameFiles = !NoRename ?? config.RenameFiles;
 
         if (!string.IsNullOrEmpty(TVPattern))
         {
@@ -49,8 +49,8 @@ public class RenameOptions : OptionsBase<RenameOptions>, IOptionsBase<RenameOpti
             config.MovieRenamePattern = MoviePattern;
         }
 
-        config.WindowsSafe = WindowsSafe;
+        config.WindowsSafe = WindowsSafe ?? config.WindowsSafe;
 
-        config.RenameSubtitles = RenameSubs;
+        config.RenameSubtitles = RenameSubs ?? config.RenameSubtitles;
     }
 }

--- a/AutoTag.CLI/Options/RenameOptions.cs
+++ b/AutoTag.CLI/Options/RenameOptions.cs
@@ -37,7 +37,10 @@ public class RenameOptions : OptionsBase<RenameOptions>, IOptionsBase<RenameOpti
 
     public void UpdateConfig(AutoTagConfig config)
     {
-        config.RenameFiles = !NoRename ?? config.RenameFiles;
+        if (NoRename.HasValue)
+        {
+            config.RenameFiles = !NoRename.Value;
+        }
 
         if (!string.IsNullOrEmpty(TVPattern))
         {
@@ -49,8 +52,14 @@ public class RenameOptions : OptionsBase<RenameOptions>, IOptionsBase<RenameOpti
             config.MovieRenamePattern = MoviePattern;
         }
 
-        config.WindowsSafe = WindowsSafe ?? config.WindowsSafe;
+        if (WindowsSafe.HasValue)
+        {
+            config.WindowsSafe = WindowsSafe.Value;
+        }
 
-        config.RenameSubtitles = RenameSubs ?? config.RenameSubtitles;
+        if (RenameSubs.HasValue)
+        {
+            config.RenameSubtitles = RenameSubs.Value;
+        }
     }
 }

--- a/AutoTag.CLI/Options/TaggingOptions.cs
+++ b/AutoTag.CLI/Options/TaggingOptions.cs
@@ -8,21 +8,21 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
     [CommandLineOption<bool>("--movie", "-m", "Movie tagging mode")]
     public bool MovieMode { get; set; }
 
-    [CommandLineOption<bool>("--no-tag", "Disable file tagging")]
-    public bool NoTag { get; set; }
-    [CommandLineOption<bool>("--no-cover", "Disable cover art tagging")]
-    public bool NoCover { get; set; }
+    [CommandLineOption<bool?>("--no-tag", "Disable file tagging")]
+    public bool? NoTag { get; set; }
+    [CommandLineOption<bool?>("--no-cover", "Disable cover art tagging")]
+    public bool? NoCover { get; set; }
 
-    [CommandLineOption<bool>("--manual", "Manually choose the TV series for a file from search results")]
-    public bool Manual { get; set; }
+    [CommandLineOption<bool?>("--manual", "Manually choose the TV series for a file from search results")]
+    public bool? Manual { get; set; }
 
-    [CommandLineOption<bool>("--extended-tagging", "Add more information to Matroska file tags. Reduces tagging speed.")]
-    public bool ExtendedTagging { get; set; }
-    [CommandLineOption<bool>("--apple-tagging", "Add extra tags to mp4 files for use with Apple devices and software")]
-    public bool AppleTagging { get; set; }
+    [CommandLineOption<bool?>("--extended-tagging", "Add more information to Matroska file tags. Reduces tagging speed.")]
+    public bool? ExtendedTagging { get; set; }
+    [CommandLineOption<bool?>("--apple-tagging", "Add extra tags to mp4 files for use with Apple devices and software")]
+    public bool? AppleTagging { get; set; }
 
-    [CommandLineOption<string>("--language", "-l", "Metadata language", "en")]
-    public string Language { get; set; } = null!;
+    [CommandLineOption<string>("--language", "-l", "Metadata language")]
+    public string? Language { get; set; }
 
     public static IEnumerable<Option> GetOptions()
     {
@@ -61,14 +61,14 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
             config.Mode = AutoTagConfig.Modes.Movie;
         }
 
-        config.TagFiles = !NoTag;
-        config.AddCoverArt = !NoCover;
+        config.TagFiles = !NoTag ?? config.TagFiles;
+        config.AddCoverArt = !NoCover ?? config.AddCoverArt;
 
-        config.ManualMode = Manual;
+        config.ManualMode = Manual ?? config.ManualMode;
 
-        config.ExtendedTagging = ExtendedTagging;
-        config.AppleTagging = AppleTagging;
+        config.ExtendedTagging = ExtendedTagging ?? config.ExtendedTagging;
+        config.AppleTagging = AppleTagging ?? config.AppleTagging;
 
-        config.Language = Language;
+        config.Language = string.IsNullOrWhiteSpace(Language) ? config.Language : Language;
     }
 }

--- a/AutoTag.CLI/Options/TaggingOptions.cs
+++ b/AutoTag.CLI/Options/TaggingOptions.cs
@@ -61,14 +61,34 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
             config.Mode = AutoTagConfig.Modes.Movie;
         }
 
-        config.TagFiles = !NoTag ?? config.TagFiles;
-        config.AddCoverArt = !NoCover ?? config.AddCoverArt;
+        if (NoTag.HasValue)
+        {
+            config.TagFiles = !NoTag.Value;
+        }
 
-        config.ManualMode = Manual ?? config.ManualMode;
+        if (NoCover.HasValue)
+        {
+            config.AddCoverArt = !NoCover.Value;
+        }
 
-        config.ExtendedTagging = ExtendedTagging ?? config.ExtendedTagging;
-        config.AppleTagging = AppleTagging ?? config.AppleTagging;
+        if (Manual.HasValue)
+        {
+            config.ManualMode = Manual.Value;
+        }
 
-        config.Language = string.IsNullOrWhiteSpace(Language) ? config.Language : Language;
+        if (ExtendedTagging.HasValue)
+        {
+            config.ExtendedTagging = ExtendedTagging.Value;
+        }
+
+        if (AppleTagging.HasValue)
+        {
+            config.AppleTagging = AppleTagging.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Language))
+        {
+            config.Language = Language;
+        }
     }
 }

--- a/autotag.sln
+++ b/autotag.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoTag.Core", "AutoTag.Core\AutoTag.Core.csproj", "{01D319B4-C0F1-421B-B65D-B854CD6AD76E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoTag.cli", "AutoTag.cli\AutoTag.cli.csproj", "{3EB7244A-0C0C-4F74-9A0F-EBB2F63156B5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoTag.cli", "AutoTag.CLI\AutoTag.CLI.csproj", "{3EB7244A-0C0C-4F74-9A0F-EBB2F63156B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
AutoTag is able to store its configuration into a configuration file. This file is loaded during the program's startup and should pre-configure the application without needing to provide command line arguments.
Unfortunately this does not work, as the parsed configuration is overridden by the command line entries, or their default values if not specified.

This PR turns the command line options into nullables, that only override the parsed configuration when they are actually set.