### PR TITLE
Feature/episode groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Ignore JetBrains config files
+.idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "args": ["/home/james/Desktop/test", "--extended-tagging"],
             "cwd": "${workspaceFolder}/AutoTag.CLI",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
-            "console": "internalConsole",
+            "console": "externalTerminal",
             "stopAtEntry": false
         },
         {

--- a/AutoTag.CLI/AutoTag.CLI.csproj
+++ b/AutoTag.CLI/AutoTag.CLI.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>autotag</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.7.0</Version>
+    <Version>3.6.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AutoTag.CLI/AutoTag.CLI.csproj
+++ b/AutoTag.CLI/AutoTag.CLI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>autotag</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>3.7.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -13,6 +13,8 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
+    <!-- needed to serialze config. see https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-8/#disabling-reflection-defaults -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <TrimMode>partial</TrimMode>
   </PropertyGroup>
 

--- a/AutoTag.CLI/AutoTag.CLI.csproj
+++ b/AutoTag.CLI/AutoTag.CLI.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>autotag</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>3.5.5</Version>
+    <Version>3.7.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AutoTag.CLI/Options/TaggingOptions.cs
+++ b/AutoTag.CLI/Options/TaggingOptions.cs
@@ -24,7 +24,7 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
     [CommandLineOption<string>("--language", "-l", "Metadata language")]
     public string? Language { get; set; }
     
-    [CommandLineOption<bool?>("--episode-group", "-g", "Manually choose episode group for tagging")] 
+    [CommandLineOption<bool?>("--episode-group", "-g", "Manually choose the Episode Group for a TV episode. Enables manual mode.")] 
     public bool? EpisodeGroup { get; set; }
 
     public static IEnumerable<Option> GetOptions()

--- a/AutoTag.CLI/Options/TaggingOptions.cs
+++ b/AutoTag.CLI/Options/TaggingOptions.cs
@@ -23,6 +23,9 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
 
     [CommandLineOption<string>("--language", "-l", "Metadata language")]
     public string? Language { get; set; }
+    
+    [CommandLineOption<bool?>("--episode-group", "-g", "Manually choose episode group for tagging")] 
+    public bool? EpisodeGroup { get; set; }
 
     public static IEnumerable<Option> GetOptions()
     {
@@ -34,6 +37,7 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
         yield return GetOption(o => o.ExtendedTagging);
         yield return GetOption(o => o.AppleTagging);
         yield return GetOption(o => o.Language);
+        yield return GetOption(o => o.EpisodeGroup);
     }
 
     public static TaggingOptions GetBoundValues(BindingContext context) =>
@@ -47,6 +51,7 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
             ExtendedTagging = GetValueForProperty(o => o.ExtendedTagging, context),
             AppleTagging = GetValueForProperty(o => o.AppleTagging, context),
             Language = GetValueForProperty(o => o.Language, context),
+            EpisodeGroup = GetValueForProperty(o => o.EpisodeGroup, context),
         };
 
     public void UpdateConfig(AutoTagConfig config)
@@ -89,6 +94,11 @@ public class TaggingOptions : OptionsBase<TaggingOptions>, IOptionsBase<TaggingO
         if (!string.IsNullOrWhiteSpace(Language))
         {
             config.Language = Language;
+        }
+
+        if (EpisodeGroup.HasValue)
+        {
+            config.EpisodeGroup = EpisodeGroup.Value;
         }
     }
 }

--- a/AutoTag.Core/AutoTag.Core.csproj
+++ b/AutoTag.Core/AutoTag.Core.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
-    <PackageReference Include="TMDbLib" Version="2.0.0" />
+    <PackageReference Include="TMDbLib" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/AutoTag.Core/AutoTagConfig.cs
+++ b/AutoTag.Core/AutoTagConfig.cs
@@ -2,7 +2,7 @@ namespace AutoTag.Core;
 public class AutoTagConfig
 {
     public enum Modes { TV, Movie };
-    public const int CurrentVer = 9;
+    public const int CurrentVer = 10;
     public int ConfigVer { get; set; } = CurrentVer;
     public Modes Mode { get; set; } = Modes.TV;
     public bool ManualMode { get; set; } = false;

--- a/AutoTag.Core/AutoTagConfig.cs
+++ b/AutoTag.Core/AutoTagConfig.cs
@@ -18,6 +18,7 @@ public class AutoTagConfig
     public bool AppleTagging { get; set; } = false;
     public bool RenameSubtitles { get; set; } = false;
     public string Language { get; set; } = "en";
+    public bool EpisodeGroup { get; set; }
     public IEnumerable<FileNameReplace> FileNameReplaces { get; set; } = Enumerable.Empty<FileNameReplace>();
 
     public bool IsTVMode() => Mode == Modes.TV;

--- a/AutoTag.Core/AutoTagSettings.cs
+++ b/AutoTag.Core/AutoTagSettings.cs
@@ -39,10 +39,7 @@ public class AutoTagSettings
             }
             finally
             {
-                if (Config == null)
-                {
-                    Config = new AutoTagConfig();
-                }
+                Config ??= new AutoTagConfig();
             }
 
             if (Config.ConfigVer != AutoTagConfig.CurrentVer)
@@ -98,10 +95,7 @@ public class AutoTagSettings
             }
         }
 
-        if (Config == null)
-        {
-            Config = new AutoTagConfig();
-        }
+        Config ??= new AutoTagConfig();
     }
 
     public void Save()

--- a/AutoTag.Core/FileMetadata.cs
+++ b/AutoTag.Core/FileMetadata.cs
@@ -41,7 +41,7 @@ public abstract class FileMetadata
 
     public abstract string GetFileName(AutoTagConfig config);
 
-    protected readonly static Regex _renameRegex = new Regex(@"%(?<num>\d+)(?:\:(?<format>[0#]+))?");
+    protected static readonly Regex _renameRegex = new Regex(@"%(?<num>\d+)(?:\:(?<format>[0#]+))?");
 
     protected static string FormatRenameNumber(Match match, int value)
     {
@@ -55,5 +55,5 @@ public abstract class FileMetadata
         }
     }
 
-    public override abstract string ToString();
+    public abstract override string ToString();
 }

--- a/AutoTag.Core/FileWriter.cs
+++ b/AutoTag.Core/FileWriter.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Caching.Memory;
 namespace AutoTag.Core;
 public class FileWriter : IDisposable
 {
-    private readonly static HttpClient _client = new HttpClient();
+    private static readonly HttpClient _client = new HttpClient();
     private static Dictionary<string, byte[]> _images = new Dictionary<string, byte[]>();
     private readonly IMemoryCache _cache;
 
@@ -176,9 +176,9 @@ public class FileWriter : IDisposable
 
     private static char[]? invalidFilenameChars { get; set; }
 
-    private readonly static char[] invalidNtfsChars = { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
+    private static readonly char[] invalidNtfsChars = { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
 
-    private readonly static string[] subtitleFileExtensions = { ".srt", ".vtt", ".sub", ".ssa" };
+    private static readonly string[] subtitleFileExtensions = { ".srt", ".vtt", ".sub", ".ssa" };
 
     public void Dispose()
     {

--- a/AutoTag.Core/TV/ShowResult.cs
+++ b/AutoTag.Core/TV/ShowResult.cs
@@ -4,23 +4,25 @@ using TMDbLib.Objects.TvShows;
 
 namespace AutoTag.Core.TV;
 
-public class ShowResult
+public partial class ShowResult
 {
+    /* settings */
+    [GeneratedRegex("(volume|season)\\s(?<episode>\\d+)")]
+    private static partial Regex EpisodeRegex();
+
+    /* vars */
     public SearchTv TvSearchResult { get; }
     private TvGroupCollection? GroupCollection { get; set; }
+    public IReadOnlyDictionary<(int season, int episode), (int season, int episode)>? EpisodeGroupMappingTable => _episodeGroupMappingTable;
+    private Dictionary<(int season, int episode), (int season, int episode)>? _episodeGroupMappingTable;
 
+    /// <summary>
+    /// Create simple ShowResult container with <see cref="SearchTv"/> base
+    /// </summary>
+    /// <param name="tvSearchResult"></param>
     public ShowResult(SearchTv tvSearchResult)
     {
         TvSearchResult = tvSearchResult;
-    } 
-    
-    /// <summary>
-    /// Add optional episode group to tv result
-    /// </summary>
-    /// <param name="episodeGroup">Episode group fetched from tmdb api</param>
-    public void AddEpisodeGroup(TvGroupCollection episodeGroup)
-    {
-        GroupCollection = episodeGroup;
     }
 
     public static implicit operator ShowResult(SearchTv tv) => new(tv);
@@ -32,5 +34,73 @@ public class ShowResult
     public static List<ShowResult> FromSearchResults(IEnumerable<SearchTv> results)
     {
         return results.Select(result => (ShowResult)result).ToList();
+    }
+
+    
+    /// <summary>
+    /// Add optional episode group to tv result
+    /// </summary>
+    /// <param name="episodeGroup">Episode group fetched from tmdb api</param>
+    public bool AddEpisodeGroup(TvGroupCollection episodeGroup)
+    {
+        if (!TryGenerateMappingTable(episodeGroup, out var mappingTable)) return false;
+
+        _episodeGroupMappingTable = mappingTable;
+        GroupCollection = episodeGroup;
+        return true;
+    }
+
+    public bool TryGetMapping(int seasonNumber, int episodeNumber, out (int season, int episode)? numbering)
+    {
+        numbering = null;
+        if (_episodeGroupMappingTable?.TryGetValue((seasonNumber, episodeNumber), out var result) ?? false)
+        {
+            numbering = result;
+            return true;
+        }
+
+        return false;
+    }
+    
+    /// <summary>
+    /// Tries to generate mapping table between TMDB standard sorting of show
+    /// and the given Episode Group
+    /// </summary>
+    /// <param name="collection">Episode Group from TMDB</param>
+    /// <param name="parsedTable">Filled parsing table. Only filled when method returns true</param>
+    /// <returns>True if successful, false if not</returns>
+    private static bool TryGenerateMappingTable(TvGroupCollection collection,
+        out Dictionary<(int season, int episode), (int season, int episode)>? parsedTable)
+    {
+        parsedTable = new Dictionary<(int season, int episode), (int season, int episode)>();
+
+        foreach (var tvGroup in collection.Groups)
+        {
+            // determine season number
+            var sanitizedGroupName = tvGroup.Name.Trim().ToLower();
+            int? seasonNumber = null;
+
+            var seasonMatch = EpisodeRegex().Match(sanitizedGroupName);
+            if (seasonMatch.Success)
+            {
+                seasonNumber = int.Parse(seasonMatch.Groups["episode"].Value);
+            }
+            else if (sanitizedGroupName.StartsWith("special"))
+            {
+                seasonNumber = 0;
+            }
+
+            if (!seasonNumber.HasValue) return false;
+
+            // create mapping
+            foreach (var episode in tvGroup.Episodes)
+            {
+                parsedTable.Add(
+                    (seasonNumber.Value, episode.Order + 1), // order starts at 0, episodes at 1
+                    (episode.SeasonNumber, episode.EpisodeNumber));
+            }
+        }
+
+        return true;
     }
 }

--- a/AutoTag.Core/TV/ShowResult.cs
+++ b/AutoTag.Core/TV/ShowResult.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+using TMDbLib.Objects.Search;
+using TMDbLib.Objects.TvShows;
+
+namespace AutoTag.Core.TV;
+
+public class ShowResult
+{
+    public SearchTv TvSearchResult { get; }
+    private TvGroupCollection? GroupCollection { get; set; }
+
+    public ShowResult(SearchTv tvSearchResult)
+    {
+        TvSearchResult = tvSearchResult;
+    } 
+    
+    /// <summary>
+    /// Add optional episode group to tv result
+    /// </summary>
+    /// <param name="episodeGroup">Episode group fetched from tmdb api</param>
+    public void AddEpisodeGroup(TvGroupCollection episodeGroup)
+    {
+        GroupCollection = episodeGroup;
+    }
+
+    public static implicit operator ShowResult(SearchTv tv) => new(tv);
+
+    /// <summary>
+    /// Generates <see cref="ShowResult"/> list from any <see cref="SearchTv"/> enumerable 
+    /// </summary>
+    /// <param name="results">Result from tmdb client</param>
+    public static List<ShowResult> FromSearchResults(IEnumerable<SearchTv> results)
+    {
+        return results.Select(result => (ShowResult)result).ToList();
+    }
+}

--- a/AutoTag.Core/TV/ShowResults.cs
+++ b/AutoTag.Core/TV/ShowResults.cs
@@ -4,7 +4,10 @@ using TMDbLib.Objects.TvShows;
 
 namespace AutoTag.Core.TV;
 
-public partial class ShowResult
+/// <summary>
+/// Container class to hold episode as well as related episode group search results
+/// </summary>
+public partial class ShowResults
 {
     /* settings */
     [GeneratedRegex("(volume|season)\\s(?<episode>\\d+)")]
@@ -20,20 +23,20 @@ public partial class ShowResult
     /// Create simple ShowResult container with <see cref="SearchTv"/> base
     /// </summary>
     /// <param name="tvSearchResult"></param>
-    public ShowResult(SearchTv tvSearchResult)
+    public ShowResults(SearchTv tvSearchResult)
     {
         TvSearchResult = tvSearchResult;
     }
 
-    public static implicit operator ShowResult(SearchTv tv) => new(tv);
+    public static implicit operator ShowResults(SearchTv tv) => new(tv);
 
     /// <summary>
-    /// Generates <see cref="ShowResult"/> list from any <see cref="SearchTv"/> enumerable 
+    /// Generates <see cref="ShowResults"/> list from any <see cref="SearchTv"/> enumerable 
     /// </summary>
     /// <param name="results">Result from tmdb client</param>
-    public static List<ShowResult> FromSearchResults(IEnumerable<SearchTv> results)
+    public static List<ShowResults> FromSearchResults(IEnumerable<SearchTv> results)
     {
-        return results.Select(result => (ShowResult)result).ToList();
+        return results.Select(result => (ShowResults)result).ToList();
     }
 
     
@@ -50,6 +53,13 @@ public partial class ShowResult
         return true;
     }
 
+    /// <summary>
+    /// Try to retrieve episode mapping for episode group order
+    /// </summary>
+    /// <param name="seasonNumber">Season number as defined in episode group</param>
+    /// <param name="episodeNumber">Episode number as defined in episode group</param>
+    /// <param name="numbering">Matching episode number and season of "standard" order</param>
+    /// <returns>True if mapping exists, false if not</returns>
     public bool TryGetMapping(int seasonNumber, int episodeNumber, out (int season, int episode)? numbering)
     {
         numbering = null;

--- a/AutoTag.Core/TV/ShowResults.cs
+++ b/AutoTag.Core/TV/ShowResults.cs
@@ -31,7 +31,7 @@ public partial class ShowResults
     public static implicit operator ShowResults(SearchTv tv) => new(tv);
 
     /// <summary>
-    /// Generates <see cref="ShowResults"/> list from any <see cref="SearchTv"/> enumerable 
+    /// Generates <see cref="ShowResults"/> list from any <see cref="SearchTv"/> enumerable
     /// </summary>
     /// <param name="results">Result from tmdb client</param>
     public static List<ShowResults> FromSearchResults(IEnumerable<SearchTv> results)
@@ -39,7 +39,7 @@ public partial class ShowResults
         return results.Select(result => (ShowResults)result).ToList();
     }
 
-    
+
     /// <summary>
     /// Add optional episode group to tv result
     /// </summary>
@@ -71,7 +71,7 @@ public partial class ShowResults
 
         return false;
     }
-    
+
     /// <summary>
     /// Tries to generate mapping table between TMDB standard sorting of show
     /// and the given Episode Group

--- a/AutoTag.Core/TV/ShowResults.cs
+++ b/AutoTag.Core/TV/ShowResults.cs
@@ -87,7 +87,7 @@ public partial class ShowResults
         foreach (var tvGroup in collection.Groups)
         {
             // determine season number
-            var sanitizedGroupName = tvGroup.Name.Trim();
+            var sanitizedGroupName = tvGroup.Name.ToLower().Trim();
             int? seasonNumber = null;
 
             var seasonMatch = EpisodeRegex().Match(sanitizedGroupName);

--- a/AutoTag.Core/TV/ShowResults.cs
+++ b/AutoTag.Core/TV/ShowResults.cs
@@ -10,7 +10,7 @@ namespace AutoTag.Core.TV;
 public partial class ShowResults
 {
     /* settings */
-    [GeneratedRegex("(volume|season)\\s(?<episode>\\d+)")]
+    [GeneratedRegex(@"^\S+\s+(?<episode>\d+)$")]
     private static partial Regex EpisodeRegex();
 
     /* vars */
@@ -87,7 +87,7 @@ public partial class ShowResults
         foreach (var tvGroup in collection.Groups)
         {
             // determine season number
-            var sanitizedGroupName = tvGroup.Name.Trim().ToLower();
+            var sanitizedGroupName = tvGroup.Name.Trim();
             int? seasonNumber = null;
 
             var seasonMatch = EpisodeRegex().Match(sanitizedGroupName);
@@ -105,9 +105,13 @@ public partial class ShowResults
             // create mapping
             foreach (var episode in tvGroup.Episodes)
             {
-                parsedTable.Add(
+                var mappingIsUnique = parsedTable.TryAdd(
                     (seasonNumber.Value, episode.Order + 1), // order starts at 0, episodes at 1
                     (episode.SeasonNumber, episode.EpisodeNumber));
+                if (!mappingIsUnique)
+                {
+                    return false;
+                }
             }
         }
 

--- a/AutoTag.Core/TV/TVProcessor.cs
+++ b/AutoTag.Core/TV/TVProcessor.cs
@@ -138,14 +138,14 @@ public class TVProcessor : IProcessor
                         var groupInfo = await _tmdb.GetTvEpisodeGroupsAsync(groups.Results[chosenGroup.Value].Id, config.Language);
                         if (groupInfo is null)
                         {
-                            setStatus($"Error: Could not retrieve TV episode groups for show {tvShow.Name}", MessageType.Error);
+                            setStatus($"Error: Could not retrieve TV episode groups for show \"{tvShow.Name}\"", MessageType.Error);
                             result.Success = false;
                             return false;
                         }
                         
                         if (!seriesResult.AddEpisodeGroup(groupInfo))
                         {
-                            setStatus($"Error: Unable to generate a unique season-episode mapping for collection group {groupInfo.Name}", MessageType.Error);
+                            setStatus($"Error: Unable to generate a unique season-episode mapping for collection group \"{groupInfo.Name}\"", MessageType.Error);
                             result.Success = false;
                             return false;
                         }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
   --extended-tagging               Add more information to Matroska file tags. Reduces tagging speed.
   --apple-tagging                  Add extra tags to mp4 files for use with Apple devices and software
   -l, --language <language>        Metadata language [default: en]
+  -g, --episode-group              Manually choose the Episode Group for a TV episode. Enables manual mode.
   --no-rename                      Disable file and subtitle renaming
   --tv-pattern <tv-pattern>        Rename pattern for TV episodes
   --movie-pattern <movie-pattern>  Rename pattern for movies
@@ -104,6 +105,18 @@ The `--extended-tagging` option adds additional information to Matroska video fi
 
 ### Language
 The language of the metadata can be set using the `-l` or `--language` option. This accepts a [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) with optional [ISO 3166 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) for regional variants. E.g., to get metadata in German use `-l de`, or for Brazilian Portuguese use `-l pt-BR`. Note that the data for other languages is probably less complete than it is for English. If data in a given language is not available it will fall back to some alternative, likely English.
+
+### Episode Groups / Alternate Ordering
+The `--episode-group` option allows you to choose one of the additional episodes group collections created on TMDB as source for the episode ordering. All contained episode groups must follow the naming scheme `<NAME> XX`. Episode groups whose names begin with `special` in their names are also valid and will be treated as `Season 0`.
+
+| Group Name      | Valid |
+|-----------------|-------|
+| Season 01       | ✅     |
+| Staffel 02      | ✅     |
+| Volume 9        | ✅     |
+| Special         | ✅     |
+| Season 3 Part 1 | ❌     |
+| Volume Part 1   | ❌     |
 
 ## Config
 AutoTag creates a config file to store default preferences at `~/.config/autotag/conf.json` or `%APPDATA%\Roaming\autotag\conf.json`. A different config file can be specified using the `-c` option. If the file does not exist, a file will be created with the default settings:


### PR DESCRIPTION
I recently came across the issue, that the standard TMDB episode order for a particular show was not matching the DVD/Bluray release one. Fortunately in many cases, there are additional "Episode Groups" available, that contain custom orders and can be accessed by via TMDBs API.

To resolve my issue, I added a new flag called "--episode-group" or short "-g". When this flag is enabled, the app first behaves like if the "--manual" flag was set - the user is asked for the right tv show. After that, a second dialog is started where the user can select the wanted episode group.

Next a mapping dictionary is created, to be able to fetch the right episode information with the groups numbers, e.g. 1x47 in an episode group is equivalent to 2x03 in TMDB's standard order. For this to work, the groups within the episode group have to have a parsable name like "Season 1" , "Volume 1" or Special (which is handles as Season 0).

I tried to work with the existing code and only modify the management of the episode numbers for the API lookups.

## Changelog:
### Updated
- System.Text.Json 7.0.3 -> 9.0.0
- Microsoft.Extensions.Caching.Memory 7.0.0 -> 9.0.0
- TMDbLib 2.0.0 -> 2.2.0

### Added
- Episode Group Support (--episode-group / -g)

### Changed
- Changed target Framework from .NET 7.0 to .NET 8.0 (LTS)
- Updated codebase with new .NET Features
- Updated codebase according to sonarqube recommendations