### PR TITLE
Fixed: Episode Group selection

### DIFF
--- a/AutoTag.CLI/AutoTag.CLI.csproj
+++ b/AutoTag.CLI/AutoTag.CLI.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>autotag</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AutoTag.Core/TV/TVProcessor.cs
+++ b/AutoTag.Core/TV/TVProcessor.cs
@@ -179,7 +179,7 @@ public class TVProcessor(ITMDBService tmdb, IFileWriter writer, ITVCache cache, 
             if (groups.Results.Count != 0)
             {
                 var options = groups.Results
-                    .Select(g => $"[{g.Type}] {g.Name} ({g.GroupCount} seasons, {g.EpisodeCount} episodes)")
+                    .Select(g => $"[[{g.Type}]] {g.Name} ({g.GroupCount} seasons, {g.EpisodeCount} episodes)")
                     .ToList();
 
                 if (searchResults.Count > 1 && i < searchResults.Count - 1)


### PR DESCRIPTION
Hi,

I just stumbled upon a bug, when trying to use the episode group feature:

```console
Error: Could not find color or style 'DVD'.
```

As it turns out, Spectre.Console uses square brackets for its markup language. A selection string like `[DVD] German DVD Order (13 seasons, 517 episodes)` results in the error above. This PR fixes this issue by escaping the brackets. 